### PR TITLE
Twitter feed

### DIFF
--- a/_includes/latest-posts.html
+++ b/_includes/latest-posts.html
@@ -11,3 +11,6 @@
 <div class="buttons is-centered">
     <a href="/news/" class="button is-primary is-outlined">All news</a>
 </div>
+
+<a class="twitter-timeline" data-height="500" href="https://twitter.com/{{ site.author.twitter }}">Tweets by @{{ site.author.twitter }}</a>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
This PR adds a Twitter feed for @PISM_model below the latest news in the sidebar, i.e., on every page which has `show_sidebar: true` set in the front matter.

Is this a good way of showing the Twitter feed on the website? Alternatively, we could also add the feed just on the landing page - but if we show the latest news in the sidebar on (almost) every page, I think it also makes sense to show the Twitter feed.